### PR TITLE
Add proxy configuration for frontend API calls

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8080",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-// For Next.js, use process.env.NEXT_PUBLIC_API_BASE_URL or fallback to localhost
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080/api';
+// For Next.js, use process.env.NEXT_PUBLIC_API_BASE_URL or fallback to local proxy
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
 export const fetchTrendingProducts = async () => {
   return axios.get(`${API_BASE_URL}/trending-products`);


### PR DESCRIPTION
## Summary
- proxy frontend requests to backend on port 8080
- use relative API base path to benefit from proxy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68894d35686883299aa6724401cda6ac